### PR TITLE
ansible-lint fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This playbook shows an example of an SMTP relay
       roles:
         - role: postfix
           vars:
-            configuration_items:
+            postfix_configuration_items:
               - name: inet_interfaces
                 value: localhost
               - name: inet_protocols

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The path to the Postfix `main.cf` configuration file.
 
 The state in which the Postfix service should be after this role runs, and whether to enable the service on startup.
 
-    configuration_items:
+    postfix_configuration_items:
         - name: inet_interfaces
           value: localhost
         - ...

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ postfix_config_file: /etc/postfix/main.cf
 postfix_service_state: started
 postfix_service_enabled: true
 
-configuration_items:
+postfix_configuration_items:
   - name: inet_interfaces
     value: localhost
   - name: inet_protocols

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
     dest: "{{ postfix_config_file }}"
     line: "{{ item.name }} = {{ item.value }}"
     regexp: "^{{ item.name }} ="
-  with_items: "{{ configuration_items }}"
+  with_items: "{{ postfix_configuration_items }}"
   notify: restart postfix
 
 - name: Ensure postfix is started and enabled at boot.


### PR DESCRIPTION
Changed name of `configuration_items` to `postfix_configuration_items`.
It should fix the following:
```
var-naming[no-role-prefix]: Variables names from within roles should use postfix_ as a prefix. (vars: configuration_items)
```